### PR TITLE
Added OAuth API Authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ async function retrieveData(userLogins, clientID, oAuth) {
   return request.get({
     url: url,
     headers: {
-      'Client-ID': 'fs7tnn3kkjowzye49l4xxex49oy539',
+      'Client-ID': clientID,
       'Authorization': 'Bearer ' + oAuth
     },
     qs: {
@@ -79,7 +79,7 @@ class TwitchStreams extends q.DesktopApp {
         return new q.Signal({
           points: [
             [
-              new q.Point('#0000FF',q.Effects.BLINK)
+              new q.Point('#b401ff',q.Effects.BLINK)
             ]
           ],
           name: `${stream.user_name} is live!`,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,24 @@
     },
     "questions": [
       {
+        "key": "clientID",
+        "label": "You need a Twitch API Client ID",
+        "help": "Your Twitch Client ID (https://dev.twitch.tv/console/)",
+        "placeholder": "123456789abcdefghijklm",
+        "required": true,
+        "order": 1,
+        "controlType": "textbox"
+      },
+      {
+        "key": "secret",
+        "label": "You need a Twitch API Secret",
+        "help": "Your Twitch API Secret (https://dev.twitch.tv/console/)",
+        "placeholder": "123456789abcdefghijklm",
+        "required": true,
+        "order": 1,
+        "controlType": "textbox"
+      },
+      {
         "key": "userLogins",
         "label": "What user do you want to follow?",
         "help": "Enter a user login like 'twitchpresents'.",

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,14 @@
 const assert = require('assert');
 const t = require('../index');
 
+const clientID = 'h653tq43o1qwda9i1q0wqmusdao4kci';
+const secret = '6k7hl0us8bcwycq43qrazyp6cc9io8';
+const oAuth = 'yy9q2rz5i49mwn0b7zabnhj7vzy2lz';
+
 describe('retrieveData', function () {
   it('retrieves data', async function () {
     const userLogins = ['twitchpresents', 'patterrz'];
-    return t.retrieveData(userLogins).then(data => {
+    return t.retrieveData(userLogins, clientID, oAuth).then(data => {
       assert.ok(data);
       console.log(JSON.stringify(data));
     })
@@ -19,7 +23,7 @@ describe('TwitchStreams', function () {
     assert.ok(signal);
     assert.equal(signal.name, 'Patterrz is live!');
     assert(signal.message.includes('Pokemon Lets Go FINALLY FIND SHINY VULPIX'));
-    assert(signal.message.includes('https://www.twitch.tv/Patterrz'));
+    assert(signal.link.url.includes('https://www.twitch.tv/Patterrz'));
   });
 
   it('#generateSignal(data) doesn\'t repeat', function () {
@@ -48,8 +52,36 @@ describe('TwitchStreams', function () {
       }).catch(error => {
         assert.ok(error);
       })
-    })  
+    })
   });
+
+  describe('#applyConfig()', function () {
+    it('rejects empty clientID', function () {
+      const app = buildApp({
+        userLogins: ['test']
+      });
+      app.applyConfig().then(() => {
+        assert.fail("Should have rejected.");
+      }).catch(error => {
+        assert.ok(error);
+      })
+    })
+  });
+
+  describe('#applyConfig()', function () {
+    it('rejects empty secret', function () {
+      const app = buildApp({
+        userLogins: ['test'],
+        clientID: 'test'
+      });
+      app.applyConfig().then(() => {
+        assert.fail("Should have rejected.");
+      }).catch(error => {
+        assert.ok(error);
+      })
+    })
+  });
+
 
   it('#run()', function () {
     const app = buildApp();
@@ -74,6 +106,8 @@ function buildApp(config) {
   const app = new t.TwitchStreams();
   app.config = config || {
     userLogins: ['twitchpresents', 'patterrz'],
+    clientID: 'h653tq43o1qwda9i1q0wqmusdao4kci',
+    secret: '6k7hl0us8bcwycq43qrazyp6cc9io8',
     geometry: {
       width: 1,
       height: 1,

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
 const t = require('../index');
 
-const clientID = 'h653tq43o1qwda9i1q0wqmusdao4kci';
-const secret = '6k7hl0us8bcwycq43qrazyp6cc9io8';
-const oAuth = 'yy9q2rz5i49mwn0b7zabnhj7vzy2lz';
+const clientID = 'PLACEHOLDER';
+const secret = 'PLACEHOLDER';
+const oAuth = 'PLACEHOLDER';
 
 describe('retrieveData', function () {
   it('retrieves data', async function () {
@@ -106,8 +106,8 @@ function buildApp(config) {
   const app = new t.TwitchStreams();
   app.config = config || {
     userLogins: ['twitchpresents', 'patterrz'],
-    clientID: 'h653tq43o1qwda9i1q0wqmusdao4kci',
-    secret: '6k7hl0us8bcwycq43qrazyp6cc9io8',
+    clientID: clientID,
+    secret: secret,
     geometry: {
       width: 1,
       height: 1,


### PR DESCRIPTION
This change is necessary since the Twitch API now expects an OAuth Token to be present for any kind of API Call (corresponding [Blog Post](https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916))

Fixed Twitch API Communication through adding the use of OAuth.
The OAuth token will be dynamically requested via the Twitch Client ID and Twitch API Secret delivered by the user.